### PR TITLE
fix: Slack Gpg Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,13 @@ Within the Disk Management window, shrink your Windows Volume to create an empty
 
 To check if your computer supports *Device Encryption*, open **Settings > Privacy & Security**. If your computer support that feature, you should see a tab called *Device Encryption*. By default, Windows 11 should turn the feature on.
 
-**NOTE: the recovery key is linked to the microsoft account associated with the user. You MUST therefore have linked Windows 11 to your Microsoft Account !**
+**NOTE: when the Device Encryption is over, you should check and save the recovery key somewhere safe:**
+* **If you linked your user account to your Microsoft Account: the recovery key can be obtained through [this Microsoft link](https://go.redirectingat.com/?id=111346X1569483&url=https://account.microsoft.com/devices/recoverykey&xcust=2-1-624599-1-0-0&sref=https://www.pcworld.com/article/624599/how-to-find-the-recovery-key-for-your-encrypted-windows-11-pc.html)**
+* **Otherwise, go to Settings > Privacy & Security >  and click on "Get recovery key"**
 
 2) BitLocker
 
-If *Device Encryption* is unavailable on your computer, turn on [BitLocker](https://learn.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-overview).
+If *Device Encryption* is unavailable on your computer, turn on [BitLocker](https://support.microsoft.com/en-us/windows/turn-on-device-encryption-0c453637-bc88-5f74-5105-741561aae838) (see the bottom of the page).
 
 **NOTE: you MUST save the recovery key somewhere safe and not on your computer**
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ This will:
 |   libfuse2    |   Filesystem in Userspace (library)     |
 |   Visual Studio Code  |   VS Code is a source-code editor made by Microsoft   |
 |   docker (& friends)  |   Pack, ship and run any application as a lightweight container   |
-|   Slack       |   Slack is a messaging program designed specifically for the office   |
+|   snapd       |   Daemon and tooling that enable snap packages    |
+|   slack (snap)|   Slack is a messaging program designed specifically for the office   |
 
 
 ### After Running The Script

--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ Within the Disk Management window, shrink your Windows Volume to create an empty
 * right click on the volume, select *Shrink Volume...*;
 * *enter the amount of space to shrink in MB*. The [minimum requirement for an Ubuntu 22.04](https://help.ubuntu.com/community/Installation/SystemRequirements) installation is 25GB (25600MB). If you can spare more space, go for it;
 
+**NOTE: if you would like to resize your Windows 11 partition down to less than half its original size, the above mentioned instruction will not work. INstead, follow:**
+* **make sure neither BitLocker nor Device Encryption is turned on on your computer**;
+* * **if Device Encryption is turned on, simply turn it off from Settings > Privacy & Security**;
+* * **if BitLocker is turned on, execute these commands from within Powershell in "Admin mode":**
+```powershell
+manag-bde --status # this command only prints status information about your device encryption
+Disable-Bitlocker -MountPoint "C:"
+manage-bde -off C:
+```
+* **download and install [AOMEI Partition Assistant](https://www.diskpart.com/download.html)**;
+* **resize the windows partition using AOMEI Partition Assistant**;
+
 ### Windows Drive Encryption
 
 1) Device Encryption

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Within the Disk Management window, shrink your Windows Volume to create an empty
 * right click on the volume, select *Shrink Volume...*;
 * *enter the amount of space to shrink in MB*. The [minimum requirement for an Ubuntu 22.04](https://help.ubuntu.com/community/Installation/SystemRequirements) installation is 25GB (25600MB). If you can spare more space, go for it;
 
-**NOTE: if you would like to resize your Windows 11 partition down to less than half its original size, the above mentioned instruction will not work. INstead, follow:**
+**NOTE: if you would like to resize your Windows 11 partition down to less than half its original size, the above mentioned instruction will not work. Instead, follow:**
 * **make sure neither BitLocker nor Device Encryption is turned on on your computer**;
 * * **if Device Encryption is turned on, simply turn it off from Settings > Privacy & Security**;
 * * **if BitLocker is turned on, execute these commands from within Powershell in "Admin mode":**
@@ -144,8 +144,8 @@ manage-bde -off C:
 To check if your computer supports *Device Encryption*, open **Settings > Privacy & Security**. If your computer support that feature, you should see a tab called *Device Encryption*. By default, Windows 11 should turn the feature on.
 
 **NOTE: when the Device Encryption is over, you should check and save the recovery key somewhere safe:**
-* **If you linked your user account to your Microsoft Account: the recovery key can be obtained through [this Microsoft link](https://go.redirectingat.com/?id=111346X1569483&url=https://account.microsoft.com/devices/recoverykey&xcust=2-1-624599-1-0-0&sref=https://www.pcworld.com/article/624599/how-to-find-the-recovery-key-for-your-encrypted-windows-11-pc.html)**
-* **Otherwise, go to Settings > Privacy & Security >  and click on "Get recovery key"**
+* **If you linked your user account to your Microsoft Account: the recovery key can be obtained through [this Microsoft link](https://account.microsoft.com/devices/recoverykey)**
+* **Otherwise, go to `Settings > Privacy & Security > Device Encryption` and click on "Manage my BitLocker parameters and then on "Save my recovery key"**
 
 2) BitLocker
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -2,7 +2,6 @@
 # VARIABLES
 ## URLS FOR .DEB PACKAGES
 CODE_DEB="https://az764295.vo.msecnd.net/stable/784b0177c56c607789f9638da7b6bf3230d47a8c/code_1.71.0-1662018389_amd64.deb"
-SLACK_DEB="https://downloads.slack-edge.com/releases/linux/4.28.171/prod/x64/slack-desktop-4.28.171-amd64.deb"
 
 # INSTALL ESSENTIAL APPLICATIONS
 ## PACKAGES
@@ -25,8 +24,7 @@ sudo systemctl enable containerd.service
 sudo systemctl start docker.service
 sudo systemctl start containerd.service
 ## SLACK
-wget $SLACK_DEB -O ./.deb/slack.deb
-sudo apt install ./.deb/slack.deb
+sudo snap install slack
 ## OFFICE PRINTER
 mkdir ./.tar
 wget https://download.brother.com/welcome/dlf006893/linux-brprinter-installer-2.2.3-1.gz -O ./.tar/printer.gz

--- a/packages.txt
+++ b/packages.txt
@@ -31,3 +31,4 @@ libxmlsec1-dev
 liblzma-dev
 libcurl4-openssl-dev
 inotify-tools
+snapd


### PR DESCRIPTION
The GPG key associated with the slack .deb package downloaded from their official site was outdated.

Fixed it by installing slack through snap.